### PR TITLE
Prefix pgcrypto hmac function with @extschema@

### DIFF
--- a/pgjwt--0.0.1.sql
+++ b/pgjwt--0.0.1.sql
@@ -27,7 +27,7 @@ WITH
       WHEN algorithm = 'HS384' THEN 'sha384'
       WHEN algorithm = 'HS512' THEN 'sha512'
       ELSE '' END AS id)  -- hmac throws error
-SELECT @extschema@.url_encode(hmac(signables, secret, alg.id)) FROM alg;
+SELECT @extschema@.url_encode(@extschema@.hmac(signables, secret, alg.id)) FROM alg;
 $$;
 
 


### PR DESCRIPTION
This PR resolves #6 

It sounds like, quoting the Postgres docs:

https://www.postgresql.org/docs/10/extend-extensions.html#EXTEND-EXTENSIONS-RELOCATION

> If any prerequisite extensions are listed in requires in the control file, their target schemas are appended to the initial setting of search_path. This allows their objects to be visible to the new extension's script file.

`pgcrypto` is listed in the control file so it should be available within this extension via `@extschema@`. And indeed, this fixes the issue for me.

Thanks!
