### PR TITLE
Check nbf and exp claims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXTENSION = pgjwt
-DATA = pgjwt--0.1.1.sql pgjwt--0.1.0--0.1.1.sql
+DATA = pgjwt--0.1.1.sql pgjwt--0.1.0--0.1.1.sql pgjwt--0.1.1--0.2.0.sql
 
 # postgres build stuff
 PG_CONFIG = pg_config

--- a/pgjwt--0.1.1--0.2.0.sql
+++ b/pgjwt--0.1.1--0.2.0.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION try_cast_double(inp text)
+RETURNS double precision AS $$
+  BEGIN
+    BEGIN
+      RETURN inp::double precision;
+    EXCEPTION
+      WHEN OTHERS THEN RETURN NULL;
+    END;
+  END;
+$$ language plpgsql IMMUTABLE;
+
+
+CREATE OR REPLACE FUNCTION verify(token text, secret text, algorithm text DEFAULT 'HS256')
+RETURNS table(header json, payload json, valid boolean) LANGUAGE sql AS $$
+  SELECT
+    jwt.header AS header,
+    jwt.payload AS payload,
+    jwt.signature_ok AND tstzrange(
+      to_timestamp(try_cast_double(jwt.payload->>'nbf')),
+      to_timestamp(try_cast_double(jwt.payload->>'exp'))
+    ) @> CURRENT_TIMESTAMP AS valid
+  FROM (
+    SELECT
+      convert_from(@extschema@.url_decode(r[1]), 'utf8')::json AS header,
+      convert_from(@extschema@.url_decode(r[2]), 'utf8')::json AS payload,
+      r[3] = @extschema@.algorithm_sign(r[1] || '.' || r[2], secret, algorithm) AS signature_ok
+    FROM regexp_split_to_array(token, '\.') r
+  ) jwt
+$$ IMMUTABLE;

--- a/pgjwt.control
+++ b/pgjwt.control
@@ -1,6 +1,6 @@
 # pgjwt extension
 comment = 'JSON Web Token API for Postgresql'
-default_version = '0.1.1'
+default_version = '0.2.0'
 relocatable = false
 requires = pgcrypto
 superuser = false


### PR DESCRIPTION
This commit adds support for the reserved nbf (not before) and exp (expires) claims. In addition to a valid signature, the current time to be within the range expressed in the nbf and exp claims. Both nbf and exp are optional: If omitted or assigned an invalid value, the lower or upper time boundary does not apply, respectively.

This PR closes #19.