### PR TITLE
Refer to function with schema-qualified name

### DIFF
--- a/pgjwt--0.1.1--0.2.0.sql
+++ b/pgjwt--0.1.1--0.2.0.sql
@@ -16,8 +16,8 @@ RETURNS table(header json, payload json, valid boolean) LANGUAGE sql AS $$
     jwt.header AS header,
     jwt.payload AS payload,
     jwt.signature_ok AND tstzrange(
-      to_timestamp(try_cast_double(jwt.payload->>'nbf')),
-      to_timestamp(try_cast_double(jwt.payload->>'exp'))
+      to_timestamp(@extschema@.try_cast_double(jwt.payload->>'nbf')),
+      to_timestamp(@extschema@.try_cast_double(jwt.payload->>'exp'))
     ) @> CURRENT_TIMESTAMP AS valid
   FROM (
     SELECT


### PR DESCRIPTION
This commit restores relocability of the extension which was broken by
not referring to a function called in verify() with @extschema@ prefix.
For more information, see
https://www.postgresql.org/docs/current/extend-extensions.html, section
extension relocatability.